### PR TITLE
Move menu tokens from foundations to component

### DIFF
--- a/src/Menu/MenuItem/styles.js
+++ b/src/Menu/MenuItem/styles.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "../../Menu/Tokens/tokens";
 
 const StyledMenuItemContainer = styled(Link)`
   display: flex;
@@ -12,12 +12,12 @@ const StyledMenuItemContainer = styled(Link)`
   background-color: ${({ $disabled, theme }) =>
     $disabled &&
     (theme?.menu?.item?.background?.disabled ||
-      inube.menu.item.background.disabled)};
+      tokens.item.background.disabled)};
 
   &:hover {
     cursor: ${({ $disabled }) => ($disabled ? "not-allowed" : "pointer")};
     background-color: ${({ theme }) =>
-      theme?.menu?.item?.background?.hover || inube.menu.item.background.hover};
+      theme?.menu?.item?.background?.hover || tokens.item.background.hover};
   }
 `;
 

--- a/src/Menu/Tokens/tokens.ts
+++ b/src/Menu/Tokens/tokens.ts
@@ -1,0 +1,31 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  avatar: {
+    appearance: "primary",
+  },
+  username: {
+    appearance: "dark",
+  },
+  client: {
+    appearance: "gray",
+  },
+  heading: {
+    appearance: "gray",
+  },
+  item: {
+    content: "dark",
+    background: {
+      hover: inube.palette.neutral.N20,
+      disabled: inube.palette.neutral.N20,
+    },
+  },
+  background: {
+    color: inube.palette.neutral.N0,
+  },
+  divider: {
+    color: inube.palette.neutral.N40,
+  },
+};
+
+export { tokens };

--- a/src/Menu/styles.js
+++ b/src/Menu/styles.js
@@ -1,4 +1,4 @@
-import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 import styled from "styled-components";
 
 const StyledMenuContainer = styled.div`
@@ -8,7 +8,7 @@ const StyledMenuContainer = styled.div`
   box-shadow: 0px 2px 3px 0px #091e4221;
   box-shadow: 0px 6px 10px 4px #091e4221;
   background-color: ${({ theme }) =>
-    theme?.menu?.background?.color || inube.menu.background.color};
+    theme?.menu?.background?.color || tokens.background.color};
 `;
 
 export { StyledMenuContainer };


### PR DESCRIPTION
This PR moves the menu tokens from the foundations folder to the component folder, updating all relevant imports to reflect the new structure and ensuring components reference the correct token paths. This change improves the overall organization, maintainability, and clarity of the codebase.