### PR TITLE
Remove divider token from `<Menu/>`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@inubekit/avatar": "^2.11.0",
-    "@inubekit/divider": "^0.7.0",
+    "@inubekit/avatar": "^2.29.0",
+    "@inubekit/divider": "^0.16.0",
     "@inubekit/foundations": "^5.11.3",
-    "@inubekit/icon": "^2.15.0",
+    "@inubekit/icon": "^2.17.0",
     "@inubekit/stack": "^3.8.0",
-    "@inubekit/text": "^2.15.0"
+    "@inubekit/text": "^2.17.0"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/src/Menu/Tokens/tokens.ts
+++ b/src/Menu/Tokens/tokens.ts
@@ -23,9 +23,6 @@ const tokens = {
   background: {
     color: inube.palette.neutral.N0,
   },
-  divider: {
-    color: inube.palette.neutral.N40,
-  },
 };
 
 export { tokens };


### PR DESCRIPTION
This PR removes the divider token from the `<Menu/>` component. The divider, previously styled using the divider token, has been eliminated to simplify the component's structure. All references to the token have been cleaned up from the relevant files to ensure consistency across the codebase. This change enhances the visual appearance of the Menu by streamlining the design and reducing unnecessary elements. The removal does not affect the core functionality of the Menu component, maintaining the user experience while simplifying the styling.