### PR TITLE
Refactor `<MenuItem/>` to `<MenuLink/>` and Implement `<MenuAction/>` Subcomponent

### DIFF
--- a/src/Menu/MenuAction/MenuAction.stories.tsx
+++ b/src/Menu/MenuAction/MenuAction.stories.tsx
@@ -1,12 +1,13 @@
 import { StoryFn } from "@storybook/react";
 import { MdAndroid } from "react-icons/md";
 import { BrowserRouter } from "react-router-dom";
-import { IMenuItem, MenuItem } from ".";
+
 import { props } from "./props";
+import { IMenuAction, MenuAction } from ".";
 
 const story = {
-  title: "navigation/Menu/MenuItem",
-  components: [MenuItem],
+  title: "navigation/Menu/MenuAction",
+  components: [MenuAction],
   tags: ["autodocs"],
   argTypes: {
     ...props,
@@ -20,29 +21,35 @@ const story = {
   ],
 };
 
-export const Default: StoryFn<IMenuItem> = (args) => <MenuItem {...args} />;
+export const Default: StoryFn<IMenuAction> = (args) => <MenuAction {...args} />;
 Default.args = {
   title: "Title",
   description: "Description",
   iconBefore: <MdAndroid />,
   spacing: "wide",
-
   disabled: false,
+  onClick: () => console.log("MenuAction clicked!"),
 };
 
-export const IconAfter: StoryFn<IMenuItem> = (args) => <MenuItem {...args} />;
+export const IconAfter: StoryFn<IMenuAction> = (args) => (
+  <MenuAction {...args} />
+);
 IconAfter.args = {
   title: "Title",
   description: "Description",
   iconAfter: <MdAndroid />,
   spacing: "wide",
   disabled: false,
+  onClick: () => console.log("MenuAction clicked with iconAfter!"),
 };
 
-export const Disabled: StoryFn<IMenuItem> = (args) => <MenuItem {...args} />;
+export const Disabled: StoryFn<IMenuAction> = (args) => (
+  <MenuAction {...args} />
+);
 Disabled.args = {
   ...Default.args,
   disabled: true,
+  onClick: () => console.log("Disabled action clicked!"),
 };
 
 export default story;

--- a/src/Menu/MenuAction/index.tsx
+++ b/src/Menu/MenuAction/index.tsx
@@ -1,21 +1,20 @@
 import { Text } from "@inubekit/text";
 import { Icon } from "@inubekit/icon";
 import { Stack } from "@inubekit/stack";
-import { MenuItemSpacingType } from "./props";
-import { StyledMenuItemContainer } from "./styles";
+import { MenuActionSpacingType } from "./props";
+import { StyledMenuActionContainer } from "./styles";
 
-interface IMenuItem {
+interface IMenuAction {
   title: string;
   description?: string;
-  spacing?: MenuItemSpacingType;
+  spacing?: MenuActionSpacingType;
   iconBefore?: React.JSX.Element;
   iconAfter?: React.JSX.Element;
   disabled?: boolean;
-  path?: string;
   onClick?: () => void;
 }
 
-function MenuItem(props: IMenuItem) {
+function MenuAction(props: IMenuAction) {
   const {
     title,
     description,
@@ -23,15 +22,13 @@ function MenuItem(props: IMenuItem) {
     iconBefore,
     iconAfter,
     disabled = false,
-    path = "#",
     onClick,
   } = props;
 
   return (
-    <StyledMenuItemContainer
+    <StyledMenuActionContainer
       $spacing={spacing}
       $disabled={disabled}
-      to={path}
       onClick={onClick}
     >
       <Stack gap="12px" alignItems="center">
@@ -62,9 +59,9 @@ function MenuItem(props: IMenuItem) {
           disabled={disabled}
         />
       )}
-    </StyledMenuItemContainer>
+    </StyledMenuActionContainer>
   );
 }
 
-export { MenuItem };
-export type { IMenuItem };
+export { MenuAction };
+export type { IMenuAction };

--- a/src/Menu/MenuAction/props.ts
+++ b/src/Menu/MenuAction/props.ts
@@ -1,6 +1,6 @@
-const menuItemSpacing = ["wide", "compact"] as const;
+const menuActionSpacing = ["wide", "compact"] as const;
 
-type MenuItemSpacingType = (typeof menuItemSpacing)[number];
+type MenuActionSpacingType = (typeof menuActionSpacing)[number];
 
 const props = {
   title: {
@@ -16,7 +16,7 @@ const props = {
   },
   spacing: {
     description:
-      "An optional value of type `MenuItemSpacingType` that controls the spacing around the menu item. The default value is `wide`.",
+      "An optional value of type `MenuActionSpacingType` that controls the spacing around the menu item. The default value is `wide`.",
   },
   iconBefore: {
     description:
@@ -32,5 +32,5 @@ const props = {
   },
 };
 
-export { menuItemSpacing, props };
-export type { MenuItemSpacingType };
+export { menuActionSpacing, props };
+export type { MenuActionSpacingType };

--- a/src/Menu/MenuAction/styles.js
+++ b/src/Menu/MenuAction/styles.js
@@ -1,8 +1,7 @@
 import styled from "styled-components";
-import { Link } from "react-router-dom";
-import { tokens } from "../../Menu/Tokens/tokens";
+import { tokens } from "../Tokens/tokens";
 
-const StyledMenuItemContainer = styled(Link)`
+const StyledMenuActionContainer = styled.div`
   display: flex;
   justify-content: space-between;
   text-decoration: none;
@@ -21,4 +20,4 @@ const StyledMenuItemContainer = styled(Link)`
   }
 `;
 
-export { StyledMenuItemContainer };
+export { StyledMenuActionContainer };

--- a/src/Menu/MenuLink/MenuLink.stories.tsx
+++ b/src/Menu/MenuLink/MenuLink.stories.tsx
@@ -1,0 +1,50 @@
+import { StoryFn } from "@storybook/react";
+import { MdAndroid } from "react-icons/md";
+import { BrowserRouter } from "react-router-dom";
+import { IMenuLink, MenuLink } from ".";
+import { props } from "./props";
+
+const story = {
+  title: "navigation/Menu/MenuLink",
+  components: [MenuLink],
+  tags: ["autodocs"],
+  argTypes: {
+    ...props,
+  },
+  decorators: [
+    (Story: StoryFn) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+};
+
+export const Default: StoryFn<IMenuLink> = (args) => <MenuLink {...args} />;
+Default.args = {
+  title: "Title",
+  description: "Description",
+  iconBefore: <MdAndroid />,
+  spacing: "wide",
+  disabled: false,
+  path: "/default-path",
+};
+
+export const IconAfter: StoryFn<IMenuLink> = (args) => <MenuLink {...args} />;
+IconAfter.args = {
+  title: "Title",
+  description: "Description",
+  iconAfter: <MdAndroid />,
+  spacing: "wide",
+  disabled: false,
+  path: "/icon-after-path",
+};
+
+export const Disabled: StoryFn<IMenuLink> = (args) => <MenuLink {...args} />;
+Disabled.args = {
+  ...Default.args,
+  disabled: true,
+  path: "/disabled-path",
+};
+
+export default story;

--- a/src/Menu/MenuLink/index.tsx
+++ b/src/Menu/MenuLink/index.tsx
@@ -1,0 +1,70 @@
+import { Text } from "@inubekit/text";
+import { Icon } from "@inubekit/icon";
+import { Stack } from "@inubekit/stack";
+import { MenuLinkSpacingType } from "./props";
+import { StyledMenuLinkContainer } from "./styles";
+
+interface IMenuLink {
+  title: string;
+  description?: string;
+  spacing?: MenuLinkSpacingType;
+  iconBefore?: React.JSX.Element;
+  iconAfter?: React.JSX.Element;
+  disabled?: boolean;
+  path?: string;
+  onClick?: () => void;
+}
+
+function MenuLink(props: IMenuLink) {
+  const {
+    title,
+    description,
+    spacing = "wide",
+    iconBefore,
+    iconAfter,
+    disabled = false,
+    path = "#",
+    onClick,
+  } = props;
+
+  return (
+    <StyledMenuLinkContainer
+      $spacing={spacing}
+      $disabled={disabled}
+      to={path}
+      onClick={onClick}
+    >
+      <Stack gap="12px" alignItems="center">
+        {iconBefore && (
+          <Icon
+            icon={iconBefore}
+            spacing="narrow"
+            size="24px"
+            appearance="dark"
+            disabled={disabled}
+          />
+        )}
+        <Stack direction="column" gap="4px">
+          <Text type="label" size="large" disabled={disabled} weight="bold">
+            {title}
+          </Text>
+          <Text type="body" size="small" appearance="gray" disabled={disabled}>
+            {description}
+          </Text>
+        </Stack>
+      </Stack>
+      {iconAfter && (
+        <Icon
+          icon={iconAfter}
+          spacing="narrow"
+          size="24px"
+          appearance="dark"
+          disabled={disabled}
+        />
+      )}
+    </StyledMenuLinkContainer>
+  );
+}
+
+export { MenuLink };
+export type { IMenuLink };

--- a/src/Menu/MenuLink/props.ts
+++ b/src/Menu/MenuLink/props.ts
@@ -1,0 +1,36 @@
+const menuLinkSpacing = ["wide", "compact"] as const;
+
+type MenuLinkSpacingType = (typeof menuLinkSpacing)[number];
+
+const props = {
+  title: {
+    description: "A string that represents the title of the menu item.",
+  },
+  path: {
+    description:
+      "Corresponds to the path of the menu item where the user will be redirected",
+  },
+  description: {
+    description:
+      "An optional string that provides additional information about the menu item.",
+  },
+  spacing: {
+    description:
+      "An optional value of type `MenuLinkSpacingType` that controls the spacing around the menu item. The default value is `wide`.",
+  },
+  iconBefore: {
+    description:
+      "An optional JSX element that represents an icon to be displayed before the title of the menu item.",
+  },
+  iconAfter: {
+    description:
+      "An optional JSX element that represents an icon to be displayed after the title of the menu item.",
+  },
+  disabled: {
+    description:
+      "An optional boolean that indicates whether the menu item is currently disabled.",
+  },
+};
+
+export { menuLinkSpacing, props };
+export type { MenuLinkSpacingType };

--- a/src/Menu/MenuLink/styles.js
+++ b/src/Menu/MenuLink/styles.js
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+import { tokens } from "../Tokens/tokens";
+
+const StyledMenuLinkContainer = styled(Link)`
+  display: flex;
+  justify-content: space-between;
+  text-decoration: none;
+  align-items: center;
+  height: ${({ $spacing }) => ($spacing === "wide" ? "40px" : "36px")};
+  padding: ${({ $spacing }) => ($spacing === "wide" ? "8px 16px" : "4px 16px")};
+  background-color: ${({ $disabled, theme }) =>
+    $disabled &&
+    (theme?.menu?.item?.background?.disabled ||
+      tokens.item.background.disabled)};
+
+  &:hover {
+    cursor: ${({ $disabled }) => ($disabled ? "not-allowed" : "pointer")};
+    background-color: ${({ theme }) =>
+      theme?.menu?.item?.background?.hover || tokens.item.background.hover};
+  }
+`;
+
+export { StyledMenuLinkContainer };

--- a/src/Menu/MenuSection/index.tsx
+++ b/src/Menu/MenuSection/index.tsx
@@ -1,5 +1,5 @@
 import { MenuHeading } from "../MenuHeading";
-import { MenuItem } from "../MenuItem";
+import { MenuLink } from "../MenuLink";
 import { Divider } from "@inubekit/divider";
 import { Stack } from "@inubekit/stack";
 import { ISection } from "./props";
@@ -26,7 +26,7 @@ function MenuSection(props: IMenuSection) {
           {section.title && <MenuHeading title={section.title} />}
           <Stack direction="column" gap={spacing === "compact" ? "4px" : "0px"}>
             {section.links.map((link, linkIndex) => (
-              <MenuItem
+              <MenuLink
                 key={linkIndex}
                 title={link.title}
                 description={link.description}

--- a/src/Menu/MenuSection/props.ts
+++ b/src/Menu/MenuSection/props.ts
@@ -1,8 +1,8 @@
-import { IMenuItem } from "../MenuLink";
+import { IMenuLink } from "../MenuLink";
 
 interface ISection {
   title?: string;
-  links: IMenuItem[];
+  links: IMenuLink[];
   divider?: boolean;
 }
 

--- a/src/Menu/MenuSection/props.ts
+++ b/src/Menu/MenuSection/props.ts
@@ -1,4 +1,4 @@
-import { IMenuItem } from "../MenuItem";
+import { IMenuItem } from "../MenuLink";
 
 interface ISection {
   title?: string;

--- a/src/Menu/index.tsx
+++ b/src/Menu/index.tsx
@@ -2,14 +2,14 @@ import { MenuUser } from "./MenuUser";
 import { MenuSection } from "./MenuSection";
 import { ISection } from "./MenuSection/props";
 import { StyledMenuContainer } from "./styles";
-import { MenuItemSpacingType } from "./MenuItem/props";
+import { MenuActionSpacingType } from "./MenuAction/props";
 
 interface IMenu {
   userName: string;
   sections: ISection[];
   businessUnit?: string;
   avatar?: boolean;
-  spacing?: MenuItemSpacingType;
+  spacing?: MenuActionSpacingType;
 }
 
 function Menu(props: IMenu) {

--- a/src/Menu/props.ts
+++ b/src/Menu/props.ts
@@ -1,4 +1,4 @@
-import { menuItemSpacing } from "./MenuItem/props";
+import { menuLinkSpacing } from "./MenuLink/props";
 
 const props = {
   userName: {
@@ -18,7 +18,7 @@ const props = {
       "A boolean indicating whether an avatar should be displayed for the user in the MenuUser component. This is optional.",
   },
   spacing: {
-    options: menuItemSpacing,
+    options: menuLinkSpacing,
     control: { type: "select" },
     description:
       "The type of spacing to be used for the items in the MenuSection component. This is of type MenuItemSpacingType. This is optional.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,14 @@
 export { Menu } from "./Menu";
 export { MenuUser } from "./Menu/MenuUser";
 export { MenuSection } from "./Menu/MenuSection";
-export { MenuItem } from "./Menu/MenuItem";
+export { MenuLink } from "./Menu/MenuLink";
+export { MenuAction } from "./Menu/MenuAction";
 
 export type { IMenu } from "./Menu";
 export type { IMenuUser } from "./Menu/MenuUser";
 export type { IMenuSection } from "./Menu/MenuSection";
-export type { IMenuItem } from "./Menu/MenuItem";
-export type { MenuItemSpacingType } from "./Menu/MenuItem/props";
+export type { IMenuLink } from "./Menu/MenuLink";
+export type { IMenuAction } from "./Menu/MenuAction";
+export type { MenuLinkSpacingType } from "./Menu/MenuLink/props";
+export type { MenuActionSpacingType } from "./Menu/MenuAction/props";
 export type { ISection } from "./Menu/MenuSection/props";


### PR DESCRIPTION
This PR refactors the  `<MenuItem/>` component, renaming it to MenuLink to clarify its purpose of handling navigation via a path prop. Additionally, a new `<MenuAction/>` subcomponent has been implemented, which looks similar to  `<MenuLink/>` but handles actions via an onClick handler instead of navigation. Storybook files for both components have been updated accordingly, with  `<MenuAction/>` stories now handling onClick events and  `<MenuLink/>` stories passing a path prop for navigation. The changes ensure a clear separation of concerns between actions and navigation within the menu components. Proper imports and file structure adjustments have been made to support these updates.